### PR TITLE
opa: Use GOMAXPROCS to size the VM pool

### DIFF
--- a/opa/opa.go
+++ b/opa/opa.go
@@ -39,7 +39,7 @@ func New() *OPA {
 	opa := &OPA{
 		memoryMinPages: 2,
 		memoryMaxPages: 0,
-		poolSize:       uint32(runtime.NumCPU()),
+		poolSize:       uint32(runtime.GOMAXPROCS(0)),
 		logError:       func(error) {},
 	}
 


### PR DESCRIPTION
Use GOMAXPROCS to size the VM pool so that we do not allocate too many
heaps in situations where OPA is limited and can only run on a small
number of cores.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>